### PR TITLE
Archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Pilorama
 
+*An QML-based [Pomodoro timer](https://en.wikipedia.org/wiki/Pomodoro_Technique).*
+
+
 ## Building on Archlinux
-```
-$ sudo pacman -S qt5-quickcontrols2 qt5-graphicaleffects qt5-graphicaleffects qt5-multimedia
-$ git clone https://github.com/eplatonoff/qml-timer
-$ cd qml-timer
-$ qmake src/qml-timer.pro 
-$ make
-$ ./qml-timer
-```
+
+    $ sudo pacman -S qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects qt5-multimedia
+    $ git clone https://github.com/eplatonoff/pilorama
+    $ cd pilorama
+    $ qmake src/pilorama.pro 
+    $ make
+    $ ./pilorama

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15.3)
-project(qml-timer)
+project(pilorama)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)

--- a/src/pilorama.desktop
+++ b/src/pilorama.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Pilorama
+Comment=Pomodoro timer
+Exec=pilorama
+Terminal=false
+Icon=pilorama
+Categories=Office;Clock;
+GenericName=Timer

--- a/src/pilorama.pro
+++ b/src/pilorama.pro
@@ -45,6 +45,5 @@ QML_DESIGNER_IMPORT_PATH =
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
+else: unix:!android: target.path = /usr/local/bin
 !isEmpty(target.path): INSTALLS += target
-


### PR DESCRIPTION
* An [*.desktop](https://specifications.freedesktop.org/desktop-entry-spec/1.4/) file added
* Project renamed to *pilorama.pro*
* Binary moved from `/opt/qml-timer/bin/qml-timer` to `/usr/local/pilorama`, so it would be in PATH