### PR TITLE
Travis CI feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# dist: trusty  # qt5-default 5.2.1
+# dist: xenial  # qt5-default 5.5.1
+dist: bionic    # qt5-default 5.9.5 - requires qt>=5.6
+language: cpp
+
+# svg   - libqt5svg5-dev
+# quick - qtdeclarative5-dev
+before_install:
+ - sudo apt update -qq
+ - sudo apt install qt5-default qtdeclarative5-dev libqt5svg5-dev
+
+script:
+ - qmake src/pilorama.pro
+ - make

--- a/README.md
+++ b/README.md
@@ -13,11 +13,22 @@
 - JSON Presets
 - Cross-platform software
 
-## Download for MacOS and Windows [![semver](https://img.shields.io/github/v/release/eplatonoff/pilorama)](https://github.com/eplatonoff/pilorama/releases/latest/)
 
-Building from source code on Archlinux
+## Installation [![semver](https://img.shields.io/github/v/release/eplatonoff/pilorama)](https://github.com/eplatonoff/pilorama/releases/latest/) [![semver](https://img.shields.io/github/release-date/eplatonoff/pilorama)](https://github.com/eplatonoff/pilorama/releases/latest/)
 
-    $ sudo pacman -S qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects qt5-multimedia
+### MacOS and Windows
+
+Precompiled builds available [here](https://github.com/eplatonoff/pilorama/releases/latest/).
+
+### Linux
+
+> Tip: Archlinux [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) package [`pilorama-git`](https://aur.archlinux.org/packages/pilorama-git/) available.
+
+Building from source:
+
+    $ sudo pacman -S qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects qt5-multimedia  # Archlinux
+    $ sudo apt install qt5-default qtdeclarative5-dev libqt5svg5-dev  # Ubuntu Bionic
+
     $ git clone https://github.com/eplatonoff/pilorama
     $ cd pilorama
     $ qmake src/pilorama.pro 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Precompiled builds available [here](https://github.com/eplatonoff/pilorama/releases/latest/).
 
-### Linux
+### Linux [![Build Status](https://travis-ci.com/eplatonoff/pilorama.svg?branch=master)](https://travis-ci.com/eplatonoff/pilorama)
 
 > Tip: Archlinux [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) package [`pilorama-git`](https://aur.archlinux.org/packages/pilorama-git/) available.
 

--- a/src/pilorama.pro
+++ b/src/pilorama.pro
@@ -45,5 +45,5 @@ QML_DESIGNER_IMPORT_PATH =
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/local/bin
+else: unix:!android: target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target

--- a/src/pilorama.pro
+++ b/src/pilorama.pro
@@ -45,5 +45,7 @@ QML_DESIGNER_IMPORT_PATH =
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/bin
+unix:
+    macx: target.path = /usr/local/bin
+    !android: target.path = /usr/bin
 !isEmpty(target.path): INSTALLS += target


### PR DESCRIPTION
This PR provides:

1. Travis continuous integration builds for main branch (Ubuntu Bionic)
2. Different `target.build` for linux (`/usr/bin` ) and mac (`/usr/local/bin` )
3. Readme update and fancy badges

@eplatonoff encouraged to sign up and allow access for [travis-ci.org](https://travis-ci.org/) though.