### PR TITLE
Add Kali Linux dependencies to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Building from source:
 
     $ sudo pacman -S qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects qt5-multimedia  # Archlinux
     $ sudo apt install qtbase5-dev qtdeclarative5-dev libqt5svg5-dev  # At least Ubuntu 18.04 Bionic and up / Debian 8 "jessie" and up
+    $ sudo apt install qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qt-labs-settings qml-module-qt-labs-platform qml-module-qtquick-dialogs # Kali Linux 2022
 
     $ git clone https://github.com/eplatonoff/pilorama
     $ cd pilorama


### PR DESCRIPTION
I am using Kali Linux 2022.1 and followed the instructions on how to build from source. Pilorama compiles successfully. However at first I couldn't run the binary as QML complained about lacking some dependencies. I was able to run the program after installing some `qml-modules` and I tough it would be nice to add them to the README as it may help other Kali users wanting to use this nice app =)

Installed packages:
```
qml-module-qt-labs-platform
qml-module-qt-labs-settings
qml-module-qtquick-controls
qml-module-qtquick-controls2
qml-module-qtquick-dialogs
```

OS Version: `Kali Linux 2022.1 (5.16.0-kali7-amd64)`