### PR TITLE
Fix Tray Icons Resolution

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(Pilorama VERSION 4.0.0 LANGUAGES CXX)
+project(Pilorama VERSION 4.0.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/assets/tray/static-day.svg
+++ b/src/assets/tray/static-day.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="128" height="128" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle cx="8" cy="8" r="7" stroke="#3C3C3C" stroke-width="2"/>
 <path d="M6.5 10.5V5.5L11 8L6.5 10.5Z" fill="#3C3C3C"/>
 </svg>

--- a/src/assets/tray/static-night.svg
+++ b/src/assets/tray/static-night.svg
@@ -1,4 +1,4 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="128" height="128" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle cx="8" cy="8" r="7" stroke="#EFEFEF" stroke-width="2"/>
 <path d="M6.5 10.5V5.5L11 8L6.5 10.5Z" fill="#EFEFEF"/>
 </svg>


### PR DESCRIPTION
Looks like the image is rasterized to size of SVG container during build process. Since the original SVG has small SVG size it looks bad on retina displays.

## Before:
<img width="591" alt="Screenshot 2024-08-29 at 10 05 39 PM" src="https://github.com/user-attachments/assets/8fb6ae31-27f7-40c8-ae52-efafd8196e17">


## After:
<img width="591" alt="Screenshot 2024-08-29 at 10 05 01 PM" src="https://github.com/user-attachments/assets/77984a3c-0d71-4cce-a8af-28d2697aac3e">
