### PR TITLE
Update wndws.iss: avoid Windows UAC popup on install

### DIFF
--- a/wndws.iss
+++ b/wndws.iss
@@ -15,7 +15,7 @@ DefaultDirName={autopf64}\{#MyAppName}
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
-;PrivilegesRequired=lowest
+PrivilegesRequired=lowest
 OutputDir=.\
 OutputBaseFilename=Pilorama_Setup
 SetupIconFile=.\src\assets\app_icons\icon.ico


### PR DESCRIPTION
Looks like we're not copying any files to system directories, so lowering privileges requested by the installer will avoid unnecessary & suspicious Windows UAC pop-up when running the installer