### PR TITLE
fix: reading and opening json files

### DIFF
--- a/src/FileDialogue.qml
+++ b/src/FileDialogue.qml
@@ -43,21 +43,22 @@ Item{
         currentFolder: StandardPaths.writableLocation(StandardPaths.DesktopLocation)
 
         onAccepted: {
-            masterModel.data = openFile(fileUrl).data
-            masterModel.title = openFile(fileUrl).title
+            masterModel.data = openFile(selectedFile).data
+            masterModel.title = openFile(selectedFile).title
             masterModel.load()
         }
     }
 
     FileDialog {
         id: saveFileDialog
+        fileMode: FileDialog.SaveFile
         nameFilters: ["JSON files (*.json)"]
         defaultSuffix : 'json'
         currentFolder: StandardPaths.writableLocation(StandardPaths.DesktopLocation) + "/" + masterModel.title + '.json'
 
         onAccepted: {
             masterModel.save()
-            masterModel.title = saveFile(fileUrl)
+            masterModel.title = saveFile(selectedFile)
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("MacOSController", &macOSController);
 
+	qputenv("QML_XHR_ALLOW_FILE_WRITE", QByteArray("1"));
+	qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+
     engine.load(url);
 
     return app.exec();


### PR DESCRIPTION
With Qt6 accessing local files via XMLHttpRequest is diabled and needs the environment variables set.

Further, the save dialog has to have the corresponding mode set. Eventually the file URL is available in the property selectedFile, not fileUrl.