### PR TITLE
Use asynchronous file saving in FileDialogue

### DIFF
--- a/src/FileDialogue.qml
+++ b/src/FileDialogue.qml
@@ -32,7 +32,7 @@ Item{
 
     function saveFile(url) {
         var request = new XMLHttpRequest();
-        request.open("PUT", url, false);
+        request.open("PUT", url, true); // async false created empty files on macos
         request.send(masterModel.data);
         return getTitle(url)
     }


### PR DESCRIPTION
Switched `saveFile` method in FileDialogue to use asynchronous XMLHttpRequest. This resolves an issue on macOS where synchronous requests were causing empty files to be created.