### PR TITLE
Fix release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release Builds
 
 on:
-  # Trigger manually or when a release or pre-release is created
   workflow_dispatch:
   release:
     types:


### PR DESCRIPTION
## Summary
- run Release Builds workflow for manual runs or when a release is created
