### PR TITLE
Update Qt version in CI workflows to 6.9.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: "6.8.2"
+        version: "6.9.1"
         modules: qtmultimedia
         cache: true
-        cache-key-prefix: ${{ runner.os }}-QtCache-6_7_2
+        cache-key-prefix: ${{ runner.os }}-QtCache-6_9_1
 
     - name: Build Application
       run: |
@@ -38,10 +38,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.2'
+        version: '6.9.1'
         modules: qtmultimedia
         cache: true
-        cache-key-prefix: ${{ runner.os }}-QtCache-6_7_2
+        cache-key-prefix: ${{ runner.os }}-QtCache-6_9_1
     - name: Setup Additional Dependencies
       shell: cmd
       run: |
@@ -63,10 +63,10 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
         with:
-          version: "6.8.2"
+          version: "6.9.1"
           modules: qtmultimedia
           cache: true
-          cache-key-prefix: ${{ runner.os }}-QtCache-6_7_2
+          cache-key-prefix: ${{ runner.os }}-QtCache-6_9_1
 
       - name: Build Application
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: "6.8.2"
+        version: "6.9.1"
         modules: qtmultimedia
         cache: true
-        cache-key-prefix: ${{ runner.os }}-QtCache-6_7_2
+        cache-key-prefix: ${{ runner.os }}-QtCache-6_9_1
 
     - name: Setup Additional Dependencies
       run: |
@@ -88,10 +88,10 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.2'
+        version: '6.9.1'
         modules: qtmultimedia
         cache: true
-        cache-key-prefix: ${{ runner.os }}-QtCache-6_7_2
+        cache-key-prefix: ${{ runner.os }}-QtCache-6_9_1
     - name: Setup Additional Dependencies
 
       shell: cmd

--- a/src/mac/bundle.sh
+++ b/src/mac/bundle.sh
@@ -3,7 +3,7 @@
 # This script is intended to be run as a "Run Script" build phase in Xcode.
 
 APP_BUNDLE_PATH="${BUILT_PRODUCTS_DIR}/${TARGET_NAME}.app"
-QT_BIN_DIR="${HOME}/bin/Qt/6.8.2/macos/bin"  # Adjust this if your Qt installation is in a different location
+QT_BIN_DIR="${HOME}/bin/Qt/6.9.1/macos/bin"  # Adjust this if your Qt installation is in a different location
 
 
 if [ "${CONFIGURATION}" == "Release" ] || [ "${CONFIGURATION}" == "MinSizeRel" ]; then


### PR DESCRIPTION
## Summary
- upgrade Qt version in GitHub workflows to 6.9.1
- update Mac bundling script to reference Qt 6.9.1
