### PR TITLE
Improve Release CI speed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ../src
-        make
+        make -j$(sysctl -n hw.ncpu)
 
     - name: Run Application Headlessly
       run: |
@@ -70,7 +70,7 @@ jobs:
       run: |
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Release ../src
-        cmake --build . --config Release
+        cmake --build . --config Release --parallel %NUMBER_OF_PROCESSORS%
 
     - name: Run Application Headlessly
       shell: pwsh
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Release ../src
-          cmake --build . --config Release
+          cmake --build . --config Release --parallel $(nproc)
 
       - name: Run Application Headlessly
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release ../src
-        make
+        make -j$(sysctl -n hw.ncpu)
 
     - name: Create a deployable application bundle
       run: |
@@ -104,7 +104,7 @@ jobs:
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release ../src
-        cmake --build . --config Release
+        cmake --build . --config Release --parallel %NUMBER_OF_PROCESSORS%
         windeployqt Release\Pilorama.exe -qmldir=../src
 
     - name: Make Installer


### PR DESCRIPTION
## Summary
- speed up release workflow by checking out shallow copy of repo
- run parallel builds on macOS and Windows
