### PR TITLE
Fix audio output device selection

### DIFF
--- a/src/NotificationSystem.qml
+++ b/src/NotificationSystem.qml
@@ -7,9 +7,14 @@ QtObject {
 
     property bool soundMuted: false
 
+    MediaDevices {
+        id: mediaDevices
+    }
+
     property SoundEffect sound: SoundEffect {
         id: soundNotification
         muted: notifications.soundMuted
+        audioDevice: mediaDevices.defaultAudioOutput
         source: "qrc:assets/sound/drum_roll.wav"
     }
 


### PR DESCRIPTION
## Summary
- ensure notification sound tracks system default audio output

## Testing
- `cmake -S src -B build` *(fails: Could NOT find Qt6Svg)*

------
https://chatgpt.com/codex/tasks/task_e_6849e41e42008330abd857f35d7e5659