### PR TITLE
Bring window forward on segment start

### DIFF
--- a/src/Components/Preferences.qml
+++ b/src/Components/Preferences.qml
@@ -247,6 +247,47 @@ Item {
                 }
             }
         }
+
+        Item {
+            id: segmentPopUp
+            height: preferences.cellHeight
+            anchors.right: parent.right
+            anchors.rightMargin: 0
+            anchors.left: parent.left
+            anchors.leftMargin: 0
+
+            Checkbox {
+                id: segmentPopUpCheck
+                checked: appSettings.showOnSegmentStart
+            }
+
+            Text {
+                id: segmentPopUpLabel
+                height: 19
+                text: qsTr("Show window on segment start")
+                anchors.right: parent.right
+                anchors.rightMargin: 0
+                anchors.left: segmentPopUpCheck.right
+                anchors.leftMargin: 0
+                color: colors.getColor("dark")
+                anchors.verticalCenter: parent.verticalCenter
+
+                font.family: localFont.name
+                font.pixelSize: fontSize
+
+                renderType: Text.NativeRendering
+            }
+
+            MouseArea {
+                id: segmentPopUpTrigger
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+
+                onReleased: {
+                    appSettings.showOnSegmentStart = !appSettings.showOnSegmentStart
+                }
+            }
+        }
         
         Item {
             id: colorTheme

--- a/src/NotificationSystem.qml
+++ b/src/NotificationSystem.qml
@@ -33,5 +33,7 @@ QtObject {
 
     function sendFromItem(item) {
         sendWithSound(masterModel.get(item.id).name)
+        if (appSettings.showOnSegmentStart)
+            tray.popUp()
     }
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -122,6 +122,7 @@ ApplicationWindow {
         property string colorTheme: "System"
         property bool showInDock: false
         property bool showPauseUI: true
+        property bool showOnSegmentStart: false
 
         property alias soundMuted: notifications.soundMuted
         property alias splitToSequence: preferences.splitToSequence


### PR DESCRIPTION
## Summary
- bring main window to the forefront whenever a new segment begins (optional)
- add checkbox in settings to control this feature