### PR TITLE
Add macOS notification on segment change

### DIFF
--- a/src/PiloramaTimer.qml
+++ b/src/PiloramaTimer.qml
@@ -57,8 +57,16 @@ Pilorama.Timer {
             const notificationsEnabled = pomodoroQueue.infiniteMode || preferences.splitToSequence;
 
             if (notificationsEnabled)
-                if (splitDuration === pomodoroQueue.itemDurationBound(first))
+                if (splitDuration === pomodoroQueue.itemDurationBound(first)) {
                     notifications.sendFromItem(first);
+                    if (Qt.platform.os === "osx") {
+                        const item = masterModel.get(first.id)
+                        const title = item.name + " started"
+                        const message = "Duration: " + item.duration / 60 +
+                                " min.  Ends at " + clock.getNotificationTime().clock
+                        MacOSController.showNotification(title, message)
+                    }
+                }
 
         } else
             splitDuration = 0;

--- a/src/mac/MacOSController.cpp
+++ b/src/mac/MacOSController.cpp
@@ -5,6 +5,7 @@
 extern void mac_show_in_dock();
 extern void mac_hide_from_dock();
 extern void mac_disable_app_nap();
+extern void mac_send_notification(const char *title, const char *message);
 #endif /* TARGET_OS_MAC */
 #endif /* __APPLE__ */
 
@@ -34,6 +35,14 @@ void MacOSController::disableAppNap() {
 #ifdef __APPLE__
 #if TARGET_OS_MAC
     mac_disable_app_nap();
+#endif /* TARGET_OS_MAC */
+#endif /* __APPLE__ */
+}
+
+void MacOSController::showNotification(const QString &title, const QString &message) {
+#ifdef __APPLE__
+#if TARGET_OS_MAC
+    mac_send_notification(title.toUtf8().constData(), message.toUtf8().constData());
 #endif /* TARGET_OS_MAC */
 #endif /* __APPLE__ */
 }

--- a/src/mac/MacOSController.h
+++ b/src/mac/MacOSController.h
@@ -14,6 +14,7 @@ public slots:
     void disableAppNap();
     void showInDock();
     void hideFromDock();
+    void showNotification(const QString &title, const QString &message);
 };
 
 #endif //PILORAMA_MACOSCONTROLLER_H

--- a/src/mac/utility.mm
+++ b/src/mac/utility.mm
@@ -20,4 +20,20 @@ void mac_show_in_dock(void) {
     [NSApp setActivationPolicy: NSApplicationActivationPolicyRegular];
 }
 
+void mac_send_notification(const char *title, const char *message) {
+    if (@available(macOS 10.8, *)) {
+        NSString *titleStr = [NSString stringWithUTF8String:title];
+        NSString *messageStr = message ? [NSString stringWithUTF8String:message] : @"";
+
+        NSUserNotification *notification = [[NSUserNotification alloc] init];
+        notification.title = titleStr;
+        notification.informativeText = messageStr;
+        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+#if !__has_feature(objc_arc)
+        [notification release];
+#endif
+    }
+}
+
+
 


### PR DESCRIPTION
## Summary
- replace dock badge with native notification implementation
- call `MacOSController.showNotification` when a segment starts
- implement `mac_send_notification` using `NSUserNotification`

## Testing
- `cmake -S src -B build` *(fails: Failed to find required Qt component)*

------
https://chatgpt.com/codex/tasks/task_e_6849e62b440c8330afb87730ef448915