### PR TITLE
Use UserNotifications explicitly in macOS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ list(FILTER HDRS EXCLUDE REGEX "^build/")
 list(FILTER QRCS EXCLUDE REGEX "^build/")
 
 IF(APPLE)
-    SET(CMAKE_EXE_LINKER_FLAGS "-framework Foundation -w")
+    SET(CMAKE_EXE_LINKER_FLAGS "-framework Foundation -framework UserNotifications -w")
     SET(PLATFORM_FILES
             mac/utility.mm
     )

--- a/src/PiloramaTimer.qml
+++ b/src/PiloramaTimer.qml
@@ -57,8 +57,16 @@ Pilorama.Timer {
             const notificationsEnabled = pomodoroQueue.infiniteMode || preferences.splitToSequence;
 
             if (notificationsEnabled)
-                if (splitDuration === pomodoroQueue.itemDurationBound(first))
+                if (splitDuration === pomodoroQueue.itemDurationBound(first)) {
                     notifications.sendFromItem(first);
+                    if (Qt.platform.os === "osx") {
+                        const item = masterModel.get(first.id)
+                        const title = item.name + " started"
+                        const message = "Duration: " + item.duration / 60 +
+                                " min.  Ends at " + clock.getNotificationTime().clock
+                        MacOSController.showNotification(title, message)
+                    }
+                }
 
         } else
             splitDuration = 0;

--- a/src/PiloramaTimer.qml
+++ b/src/PiloramaTimer.qml
@@ -59,13 +59,6 @@ Pilorama.Timer {
             if (notificationsEnabled)
                 if (splitDuration === pomodoroQueue.itemDurationBound(first)) {
                     notifications.sendFromItem(first);
-                    if (Qt.platform.os === "osx") {
-                        const item = masterModel.get(first.id)
-                        const title = item.name + " started"
-                        const message = "Duration: " + item.duration / 60 +
-                                " min.  Ends at " + clock.getNotificationTime().clock
-                        MacOSController.showNotification(title, message)
-                    }
                 }
 
         } else

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -72,6 +72,13 @@ SystemTrayIcon {
         return "image://tray_icon_provider/" + color + "_" + placeholderColor + "_" + renderSecs;
     }
 
+    function notificationIconURL() {
+        const color = pomodoroQueue.infiniteMode ?
+                colors.getThemeColor(masterModel.get(pomodoroQueue.first().id).color) :
+                colors.getThemeColor("dark");
+        return "image://notification_dot_provider/" + color;
+    }
+
     function setDialTime() {
         var t
         if(!pomodoroQueue.infiniteMode) {
@@ -118,11 +125,11 @@ SystemTrayIcon {
             message = "Duration: " + globalTimer.durationBound / 60 + " min"
             showfor = 10000
         }
-        var icon = iconURL()
+
         if (Qt.platform.os === "osx") {
-            MacOSController.showNotification(title, message, icon)
+            MacOSController.showNotification(title, message, notificationIconURL())
         } else {
-            showMessage(title, message, icon, showfor)
+            showMessage(title, message, iconURL(), showfor)
         }
     }
 

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -119,8 +119,11 @@ SystemTrayIcon {
             showfor = 10000
         }
         var icon = iconURL()
-        showMessage(title, message, icon, showfor)
-        MacOSController.showNotification(title, message, icon)
+        if (Qt.platform.os === "osx") {
+            MacOSController.showNotification(title, message, icon)
+        } else {
+            showMessage(title, message, icon, showfor)
+        }
     }
 
     function popUp(){

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -118,8 +118,9 @@ SystemTrayIcon {
             message = "Duration: " + globalTimer.durationBound / 60 + " min"
             showfor = 10000
         }
-        showMessage(title, message, iconURL(), showfor)
-        MacOSController.showNotification(title, message)
+        var icon = iconURL()
+        showMessage(title, message, icon, showfor)
+        MacOSController.showNotification(title, message, icon)
     }
 
     function popUp(){

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -119,6 +119,7 @@ SystemTrayIcon {
             showfor = 10000
         }
         showMessage(title, message, iconURL(), showfor)
+        MacOSController.showNotification(title, message)
     }
 
     function popUp(){

--- a/src/mac/MacOSController.cpp
+++ b/src/mac/MacOSController.cpp
@@ -6,7 +6,8 @@ extern void mac_show_in_dock();
 extern void mac_hide_from_dock();
 extern void mac_disable_app_nap();
 extern void mac_request_notification_permission();
-extern void mac_send_notification(const char *title, const char *message);
+extern void mac_send_notification(const char *title, const char *message,
+                                  const char *icon);
 #endif /* TARGET_OS_MAC */
 #endif /* __APPLE__ */
 
@@ -54,17 +55,22 @@ void MacOSController::requestNotificationPermission()
 #endif /* __APPLE__ */
 }
 
-void MacOSController::showNotification(const QString &title, const QString &message)
+void MacOSController::showNotification(const QString &title, const QString &message,
+                                       const QString &iconPath)
 {
 #ifdef __APPLE__
 #if TARGET_OS_MAC
-    mac_send_notification(title.toUtf8().constData(), message.toUtf8().constData());
+    mac_send_notification(title.toUtf8().constData(),
+                          message.toUtf8().constData(),
+                          iconPath.toUtf8().constData());
 #else
     Q_UNUSED(title)
     Q_UNUSED(message)
+    Q_UNUSED(iconPath)
 #endif /* TARGET_OS_MAC */
 #else
     Q_UNUSED(title)
     Q_UNUSED(message)
+    Q_UNUSED(iconPath)
 #endif /* __APPLE__ */
 }

--- a/src/mac/MacOSController.cpp
+++ b/src/mac/MacOSController.cpp
@@ -5,11 +5,18 @@
 extern void mac_show_in_dock();
 extern void mac_hide_from_dock();
 extern void mac_disable_app_nap();
+extern void mac_request_notification_permission();
+extern void mac_send_notification(const char *title, const char *message);
 #endif /* TARGET_OS_MAC */
 #endif /* __APPLE__ */
 
 MacOSController::MacOSController(QObject *parent) : QObject(parent)
 {
+#ifdef __APPLE__
+#if TARGET_OS_MAC
+    mac_request_notification_permission();
+#endif /* TARGET_OS_MAC */
+#endif /* __APPLE__ */
 }
 
 void MacOSController::showInDock()
@@ -35,5 +42,29 @@ void MacOSController::disableAppNap() {
 #if TARGET_OS_MAC
     mac_disable_app_nap();
 #endif /* TARGET_OS_MAC */
+#endif /* __APPLE__ */
+}
+
+void MacOSController::requestNotificationPermission()
+{
+#ifdef __APPLE__
+#if TARGET_OS_MAC
+    mac_request_notification_permission();
+#endif /* TARGET_OS_MAC */
+#endif /* __APPLE__ */
+}
+
+void MacOSController::showNotification(const QString &title, const QString &message)
+{
+#ifdef __APPLE__
+#if TARGET_OS_MAC
+    mac_send_notification(title.toUtf8().constData(), message.toUtf8().constData());
+#else
+    Q_UNUSED(title)
+    Q_UNUSED(message)
+#endif /* TARGET_OS_MAC */
+#else
+    Q_UNUSED(title)
+    Q_UNUSED(message)
 #endif /* __APPLE__ */
 }

--- a/src/mac/MacOSController.cpp
+++ b/src/mac/MacOSController.cpp
@@ -1,5 +1,45 @@
 #include "MacOSController.h"
 
+#include <QPixmap>
+#include <QQmlEngine>
+#include <QQuickImageProvider>
+#include <QDir>
+#include <QUrl>
+
+
+static QString prepareIconFile(const QString &iconPath, const QQmlEngine *engine)
+{
+    const QUrl url(iconPath);
+    if (url.isLocalFile()) {
+        return url.toLocalFile();
+    }
+
+    QPixmap pix;
+
+    const QString providerId = url.host();
+    if (const auto provider = qobject_cast<QQuickImageProvider*>(engine->imageProvider(providerId))) {
+        const QString requestId = url.toString().remove(0, url.toString().indexOf("#"));
+        QSize size;
+        pix = provider->requestPixmap(requestId, &size, QSize());
+    }
+    else {
+        qWarning() << "Failed to get image provider for:" << providerId;
+    }
+
+    if (pix.isNull()) {
+        qWarning() << "Failed to load image, returning empty path";
+        return {};
+    }
+
+    const QString tempFile = QDir::temp().filePath("pilorama_notify_icon.png");
+    if (!pix.save(tempFile, "PNG")) {
+        qWarning() << "Failed to save image to temp file:" << tempFile;
+        return {};
+    }
+    qDebug() << "Saved image to temp file:" << tempFile;
+    return tempFile;
+}
+
 #ifdef __APPLE__
 #if TARGET_OS_MAC
 extern void mac_show_in_dock();
@@ -18,6 +58,10 @@ MacOSController::MacOSController(QObject *parent) : QObject(parent)
     mac_request_notification_permission();
 #endif /* TARGET_OS_MAC */
 #endif /* __APPLE__ */
+}
+
+void MacOSController::setEngine(QQmlEngine* engine) {
+    engine_ = engine;
 }
 
 void MacOSController::showInDock()
@@ -56,13 +100,17 @@ void MacOSController::requestNotificationPermission()
 }
 
 void MacOSController::showNotification(const QString &title, const QString &message,
-                                       const QString &iconPath)
-{
+                                       const QString &iconPath) const {
 #ifdef __APPLE__
 #if TARGET_OS_MAC
+    if (engine_ == nullptr) {
+        qWarning() << "Engine is not set";
+        return;
+    }
+    const QString iconFile = prepareIconFile(iconPath, engine_);
     mac_send_notification(title.toUtf8().constData(),
                           message.toUtf8().constData(),
-                          iconPath.toUtf8().constData());
+                          iconFile.toUtf8().constData());
 #else
     Q_UNUSED(title)
     Q_UNUSED(message)

--- a/src/mac/MacOSController.h
+++ b/src/mac/MacOSController.h
@@ -5,19 +5,26 @@
 #include <QObject>
 #include <QString>
 
+class QQmlEngine;
+
 class MacOSController : public QObject
 {
     Q_OBJECT
 public:
     explicit MacOSController(QObject *parent = nullptr);
+    void setEngine(QQmlEngine *engine);
 
 public slots:
-    void disableAppNap();
-    void showInDock();
-    void hideFromDock();
-    void requestNotificationPermission();
+    static void disableAppNap();
+    static void showInDock();
+    static void hideFromDock();
+    static void requestNotificationPermission();
+
     void showNotification(const QString &title, const QString &message,
-                          const QString &iconPath);
+                          const QString &iconPath) const;
+
+private:
+    QQmlEngine *engine_ = nullptr;
 };
 
 #endif //PILORAMA_MACOSCONTROLLER_H

--- a/src/mac/MacOSController.h
+++ b/src/mac/MacOSController.h
@@ -3,6 +3,7 @@
 
 
 #include <QObject>
+#include <QString>
 
 class MacOSController : public QObject
 {
@@ -14,6 +15,8 @@ public slots:
     void disableAppNap();
     void showInDock();
     void hideFromDock();
+    void requestNotificationPermission();
+    void showNotification(const QString &title, const QString &message);
 };
 
 #endif //PILORAMA_MACOSCONTROLLER_H

--- a/src/mac/MacOSController.h
+++ b/src/mac/MacOSController.h
@@ -16,7 +16,8 @@ public slots:
     void showInDock();
     void hideFromDock();
     void requestNotificationPermission();
-    void showNotification(const QString &title, const QString &message);
+    void showNotification(const QString &title, const QString &message,
+                          const QString &iconPath);
 };
 
 #endif //PILORAMA_MACOSCONTROLLER_H

--- a/src/mac/utility.mm
+++ b/src/mac/utility.mm
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <Foundation/NSProcessInfo.h>
 #import <AppKit/AppKit.h>
+#import <UserNotifications/UserNotifications.h>
 
 void mac_disable_app_nap(void)
 {
@@ -18,6 +19,28 @@ void mac_hide_from_dock(void) {
 
 void mac_show_in_dock(void) {
     [NSApp setActivationPolicy: NSApplicationActivationPolicyRegular];
+}
+
+void mac_request_notification_permission(void)
+{
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound)
+                          completionHandler:^(BOOL granted, NSError * _Nullable error) {
+                              
+                          }];
+}
+
+void mac_send_notification(const char *title, const char *message)
+{
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.title = [NSString stringWithUTF8String:title];
+    content.body = [NSString stringWithUTF8String:message];
+
+    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
+                                                                          content:content
+                                                                          trigger:nil];
+
+    [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:request withCompletionHandler:nil];
 }
 
 

--- a/src/mac/utility.mm
+++ b/src/mac/utility.mm
@@ -30,11 +30,28 @@ void mac_request_notification_permission(void)
                           }];
 }
 
-void mac_send_notification(const char *title, const char *message)
+void mac_send_notification(const char *title, const char *message,
+                           const char *icon)
 {
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
     content.title = [NSString stringWithUTF8String:title];
     content.body = [NSString stringWithUTF8String:message];
+
+    if (icon && strlen(icon) > 0) {
+        NSString *iconPath = [NSString stringWithUTF8String:icon];
+        NSURL *url = [NSURL URLWithString:iconPath];
+        if ([url isFileURL]) {
+            NSError *attachError = nil;
+            UNNotificationAttachment *attachment =
+                [UNNotificationAttachment attachmentWithIdentifier:@"icon"
+                                                             URL:url
+                                                         options:nil
+                                                           error:&attachError];
+            if (!attachError && attachment) {
+                content.attachments = @[ attachment ];
+            }
+        }
+    }
 
     UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:[[NSUUID UUID] UUIDString]
                                                                           content:content

--- a/src/mac/utility.mm
+++ b/src/mac/utility.mm
@@ -39,8 +39,16 @@ void mac_send_notification(const char *title, const char *message,
 
     if (icon && strlen(icon) > 0) {
         NSString *iconPath = [NSString stringWithUTF8String:icon];
-        NSURL *url = [NSURL URLWithString:iconPath];
-        if ([url isFileURL]) {
+        NSURL *url = nil;
+        if ([iconPath hasPrefix:@"file://"]) {
+            url = [NSURL URLWithString:iconPath];
+        } else if ([iconPath hasPrefix:@"/"]) {
+            url = [NSURL fileURLWithPath:iconPath];
+        } else {
+            url = [NSURL URLWithString:iconPath];
+        }
+
+        if (url && [url isFileURL]) {
             NSError *attachError = nil;
             UNNotificationAttachment *attachment =
                 [UNNotificationAttachment attachmentWithIdentifier:@"icon"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "piloramatimer.h"
 #include "trayimageprovider.h"
+#include "notificationdotprovider.h"
 #include "mac/MacOSController.h"
 
 #include <QGuiApplication>
@@ -27,6 +28,8 @@ int main(int argc, char *argv[])
 
     QQmlApplicationEngine engine;
     engine.addImageProvider("tray_icon_provider", new TrayImageProvider());
+    engine.addImageProvider("notification_dot_provider", new NotificationDotProvider());
+    macOSController.setEngine(&engine);
 
     const QUrl url(QStringLiteral("qrc:/main.qml"));
 

--- a/src/notificationdotprovider.cpp
+++ b/src/notificationdotprovider.cpp
@@ -1,0 +1,36 @@
+#include "notificationdotprovider.h"
+#include <QPainter>
+
+NotificationDotProvider::NotificationDotProvider() : QQuickImageProvider(QQuickImageProvider::Pixmap)
+{
+}
+
+QPixmap NotificationDotProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
+{
+    Q_UNUSED(requestedSize);
+    const QColor color(id);
+    if (!color.isValid()) {
+        qWarning() << "Invalid color:" << id;
+        return {};
+    }
+
+    constexpr int width = 100, height = 100;
+    constexpr int dotSize = 50;
+
+    if (size)
+        *size = QSize(width, height);
+
+    QPixmap pix(width, height);
+    pix.fill(Qt::transparent);
+
+    QPainter painter(&pix);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setBrush(color);
+    painter.setPen(Qt::NoPen);
+    constexpr int offsetX = (width - dotSize) / 2;
+    constexpr int offsetY = (height - dotSize) / 2;
+    painter.drawRoundedRect(offsetX, offsetY, dotSize, dotSize, dotSize / 2, dotSize / 2);
+    painter.end();
+
+    return pix;
+}

--- a/src/notificationdotprovider.h
+++ b/src/notificationdotprovider.h
@@ -1,0 +1,14 @@
+#ifndef NOTIFICATIONDOTPROVIDER_H
+#define NOTIFICATIONDOTPROVIDER_H
+
+#include <QQuickImageProvider>
+
+class NotificationDotProvider : public QQuickImageProvider
+{
+public:
+    NotificationDotProvider();
+
+    QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize) override;
+};
+
+#endif // NOTIFICATIONDOTPROVIDER_H


### PR DESCRIPTION
## Summary
- add macOS notification permission and send helpers
- call permission request on startup
- notify via UserNotifications API from QML
- notification icons include a colored dot of the current segment
