### PR TITLE
Improve tray icon update frequency

### DIFF
--- a/src/PiloramaTimer.qml
+++ b/src/PiloramaTimer.qml
@@ -15,6 +15,7 @@ Pilorama.Timer {
     onDurationChanged: {
         window.checkClockMode();
         time.updateTime();
+        tray.updateRunningTime()
         canvas.requestPaint();
     }
 
@@ -24,6 +25,7 @@ Pilorama.Timer {
         canvas.requestPaint();
         if ( running ) {
             durationBound = duration;
+            tray.updateRunningTime(0, true)
         }
     }
 
@@ -64,7 +66,8 @@ Pilorama.Timer {
         } else
             splitDuration = 0;
 
-        tray.setTime()
+        tray.updateRunningTime(elapsedSecs)
+
         canvas.requestPaint();
     }
 }

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -18,6 +18,8 @@ SystemTrayIcon {
 
     property real dialTime: 0
     property real runningTime: 0
+    property int trayUpdateInterval: 5
+    property int trayUpdateCounter: 0
 
     onMessageClicked: popUp()
     onActivated: (reason) => {
@@ -95,6 +97,26 @@ SystemTrayIcon {
         runningTime = pomodoroQueue.infiniteMode ? globalTimer.splitDuration : globalTimer.duration
         setDialTime()
         updateTime()
+    }
+
+    function computeUpdateInterval() {
+        const secs = pomodoroQueue.infiniteMode ? globalTimer.splitDuration : globalTimer.duration
+        if (secs <= 120)
+            return 2
+        else if (secs <= 600)
+            return 5
+        else
+            return 10
+    }
+
+    function updateRunningTime(elapsedSecs = 0, force = false) {
+        runningTime = pomodoroQueue.infiniteMode ? globalTimer.splitDuration : globalTimer.duration
+        trayUpdateCounter += elapsedSecs
+        trayUpdateInterval = computeUpdateInterval()
+        if (force || trayUpdateCounter >= trayUpdateInterval || runningTime <= 0) {
+            setTime()
+            trayUpdateCounter = 0
+        }
     }
 
     function pad(value) {


### PR DESCRIPTION
## Summary
- centralize tray icon update logic in `TrayIcon.qml`
- compute the icon refresh interval based on the remaining duration
- keep timer simple by delegating tray updates to `TrayIcon`

## Testing
- `cmake ../src` *(fails: Qt6 missing)*
- `make -j2` *(fails: no makefile generated)*


------
https://chatgpt.com/codex/tasks/task_e_6861c13096c48330b929f2b5261503df