### PR TITLE
Show queue only while running split sequence

### DIFF
--- a/src/Components/Sequence.qml
+++ b/src/Components/Sequence.qml
@@ -10,11 +10,24 @@ Item {
     id: sequence
 
     property bool blockEdits: globalTimer.remainingTime || globalTimer.running || pomodoroQueue.count > 0
-    property bool showQueue: true
+    // Display the burner queue while the timer is running or while the
+    // timer dial is being dragged in the non‑infinite "split to sequence"
+    // mode.  This keeps the master model visible on startup and whenever the
+    // timer is idle.
+    readonly property bool queueMode: !pomodoroQueue.infiniteMode &&
+                                      preferences.splitToSequence &&
+                                      (globalTimer.running || mouseArea.dragging)
 
     function setCurrentItem(id){
         if(id === undefined){ id = -1 }
-        sequenceView.currentIndex = id
+        if(queueMode){
+            // Highlight the first queue item only when a valid segment index is
+            // provided (i.e. while the timer is running).  When called with
+            // -1 during a drag, clear the highlight.
+            queueView.currentIndex = id >= 0 && pomodoroQueue.count > 0 ? 0 : -1
+        } else {
+            sequenceView.currentIndex = id
+        }
     }
 
 
@@ -37,6 +50,7 @@ Item {
 
         ListView {
             id: sequenceView
+            visible: !sequence.queueMode
             anchors.fill: parent
             spacing: 0
             orientation: ListView.Vertical
@@ -50,23 +64,7 @@ Item {
 
             model: masterModel
 
-            delegate: Item {
-                id: delegateItem
-
-                width: sequenceView.itemWidth
-                height: sequenceView.itemHeight
-
-                SequenceItem {id: sequenceItem }
-
-                DropArea {
-                    anchors.fill: parent
-                    keys: ["sequenceItems"]
-                    onEntered: (drag) => {
-                        var draggedId = drag.source.dragItemIndex
-                        masterModel.move(draggedId, index, 1)
-                    }
-                }
-            }
+            delegate: masterDelegate
 
             addDisplaced: Transition {
                 NumberAnimation {properties: "x, y"; duration: 100}
@@ -85,6 +83,162 @@ Item {
 
             displaced: Transition {
                 NumberAnimation {properties: "x, y"; duration: 100}
+            }
+        }
+
+        ListView {
+            id: queueView
+            visible: sequence.queueMode
+            anchors.fill: parent
+            spacing: 0
+            orientation: ListView.Vertical
+            clip: true
+            snapMode: ListView.SnapToItem
+            footerPositioning: ListView.OverlayFooter
+            currentIndex: -1
+
+            property int itemWidth: width
+            property int itemHeight: 38
+
+            model: pomodoroQueue
+
+            delegate: queueDelegate
+
+            addDisplaced: Transition {
+                NumberAnimation {properties: "x, y"; duration: 100}
+            }
+            moveDisplaced: Transition {
+                NumberAnimation { properties: "x, y"; duration: 100 }
+            }
+            remove: Transition {
+                NumberAnimation { properties: "x, y"; duration: 100 }
+                NumberAnimation { properties: "opacity"; duration: 100}
+            }
+
+            removeDisplaced: Transition {
+                NumberAnimation { properties: "x, y"; duration: 100 }
+            }
+
+            displaced: Transition {
+                NumberAnimation {properties: "x, y"; duration: 100}
+            }
+        }
+
+        Component {
+            id: masterDelegate
+            Item {
+                id: delegateItem
+                width: sequenceView.itemWidth
+                height: sequenceView.itemHeight
+
+                SequenceItem { id: sequenceItem }
+
+                DropArea {
+                    anchors.fill: parent
+                    keys: ["sequenceItems"]
+                    onEntered: (drag) => {
+                        var draggedId = drag.source.dragItemIndex
+                        masterModel.move(draggedId, index, 1)
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: queueDelegate
+            Rectangle {
+                id: queueItem
+                width: queueView.itemWidth
+                height: queueView.itemHeight
+                color: colors.getColor('bg')
+
+                property var masterItem: masterModel.get(model.id)
+                property bool currentItem: queueItem.ListView.isCurrentItem
+
+                Rectangle {
+                    id: colorIndicator
+                    width: 13
+                    height: 13
+                    radius: 30
+                    color: colors.getColor(masterItem.color)
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                }
+
+                Timer {
+                    id: blinkTimer
+                    interval: 500
+                    repeat: true
+                    running: false
+                    onTriggered: colorIndicator.opacity = colorIndicator.opacity ? 0 : 1
+                }
+
+                Connections {
+                    target: globalTimer
+                    function onRunningChanged(running) {
+                        blinkTimer.running = running && sequence.queueMode && currentItem && masterItem.duration !== 0
+                        if (!blinkTimer.running)
+                            colorIndicator.opacity = 1
+                    }
+                }
+
+                Connections {
+                    target: sequence
+                    function onQueueModeChanged() {
+                        blinkTimer.running = globalTimer.running && sequence.queueMode && currentItem && masterItem.duration !== 0
+                        if (!blinkTimer.running)
+                            colorIndicator.opacity = 1
+                    }
+                }
+
+                Component.onCompleted: {
+                    blinkTimer.running = globalTimer.running && sequence.queueMode && currentItem && masterItem.duration !== 0
+                }
+
+                onCurrentItemChanged: {
+                    blinkTimer.running = globalTimer.running && sequence.queueMode && currentItem && masterItem.duration !== 0
+                    if (!blinkTimer.running)
+                        colorIndicator.opacity = 1
+                }
+
+                Text {
+                    text: masterItem.name
+                    anchors.left: parent.left
+                    anchors.leftMargin: 32
+                    anchors.verticalCenter: parent.verticalCenter
+                    font.family: localFont.name
+                    font.pixelSize: 14
+                    color: colors.getColor('dark')
+                    renderType: Text.NativeRendering
+                }
+
+                Text {
+                    // Round up to avoid an instant one-minute drop when the
+                    // timer starts and seconds decrease from a whole minute
+                    // value like 300 to 299. This keeps the displayed minutes
+                    // consistent with the dial until an entire minute elapses.
+                    text: Math.ceil(model.duration / 60)
+                    anchors.right: qMin.left
+                    anchors.rightMargin: 18
+                    anchors.verticalCenter: parent.verticalCenter
+                    font.family: localFont.name
+                    font.pixelSize: 14
+                    color: colors.getColor('dark')
+                    renderType: Text.NativeRendering
+                }
+
+                Text {
+                    id: qMin
+                    width: 30
+                    text: qsTr("min")
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    font.family: localFont.name
+                    font.pixelSize: 14
+                    color: colors.getColor('mid')
+                    renderType: Text.NativeRendering
+                }
             }
         }
     }

--- a/src/Components/Sequence/SequenceItem.qml
+++ b/src/Components/Sequence/SequenceItem.qml
@@ -138,7 +138,9 @@ Rectangle {
         id: itemtime
         width: 20
         color: sequenceItem.dimmer()
-        text: Math.trunc( model.duration / 60 )
+        // Round up here as well so the displayed minutes remain stable when
+        // the timer starts and the duration drops by a few seconds.
+        text: Math.ceil(model.duration / 60)
 
         validator: IntValidator { bottom: 1; top: globalTimer.timerLimit / 60}
         inputMethodHints: Qt.ImhDigitsOnly

--- a/src/MouseTracker.qml
+++ b/src/MouseTracker.qml
@@ -23,6 +23,10 @@ MouseArea {
 
     property real _totalRotatedSecsLimit: globalTimer.timerLimit
 
+    // Indicates that the timer dial is actively dragged. Used by the
+    // sequence view to preview the queue while the user adjusts the timer.
+    property bool dragging: false
+
     onReleased: {
         cursorShape = Qt.OpenHandCursor
         if (globalTimer.remainingTime > 0) {
@@ -33,6 +37,7 @@ MouseArea {
             window.clockMode = "start"
             notifications.stopSound()
         }
+        dragging = false
     }
 
     onRotated: (delta) => {
@@ -72,6 +77,7 @@ MouseArea {
         pomodoroQueue.count > 1 ? pomodoroQueue.restoreDuration(0) : undefined
         pomodoroQueue.infiniteMode = false
         sequence.setCurrentItem(-1)
+        dragging = true
     }
 
     onPositionChanged: (mouse) => {

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -41,6 +41,17 @@ SystemTrayIcon {
         }
     }
 
+    Connections {
+        target: globalTimer
+        function onRunningChanged(running) {
+            if (!running) {
+                // Restore the static idle icon once the timer stops
+                icon.source = iconURL()
+                trayUpdateCounter = remainingTime
+            }
+        }
+    }
+
     function checkMenuItemText() {
         if (globalTimer.running && pomodoroQueue.infiniteMode) {
             return "Reset Timer"

--- a/src/main.qml
+++ b/src/main.qml
@@ -134,7 +134,6 @@ ApplicationWindow {
 
         property alias alwaysOnTop: window.alwaysOnTop
         property alias quitOnClose: window.quitOnClose
-        property alias showQueue: sequence.showQueue
 
         onDarkModeChanged: { canvas.requestPaint(); }
         onSplitToSequenceChanged: { canvas.requestPaint(); }


### PR DESCRIPTION
## Summary
- show the queue while dragging the timer dial so users preview the split sequence
- switch current index logic to clear highlight when not running
- round up duration display so starting the timer doesn't immediately reduce minutes
- start blinking of the current queue item as soon as it becomes active
- reset tray icon when the timer stops so idle icon is shown in non-infinite mode

## Testing
- `cmake -S . -B build` *(fails: source directory has no `CMakeLists.txt`)*
- `cmake -S src -B build` *(fails: could not find Qt6)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6868368b64f8833095d33de6e2cb7a0f