### PR TITLE
Remove QWidget dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Qt6 REQUIRED COMPONENTS
         Core
         Quick
-        Widgets
         Svg
         Xml
         Multimedia
@@ -92,7 +91,6 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE QT_DEPRECATED_WARNINGS)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt::Quick
-        Qt::Widgets
         Qt::Svg
         Qt::Xml
         PRIVATE Qt6::Core

--- a/src/TrayIcon.qml
+++ b/src/TrayIcon.qml
@@ -196,6 +196,7 @@ SystemTrayIcon {
         MenuItem {
             text: qsTr("Quit")
             onTriggered: {
+                window.quitOnClose = true
                 window.close()
                 Qt.quit()
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,9 +7,6 @@
 #include <QQmlApplicationEngine>
 #include <QTimer>
 #include <QDebug>
-#include <QSystemTrayIcon>
-#include <QPixmap>
-#include <QApplication>
 #include <QQmlContext>
 
 
@@ -18,7 +15,7 @@ int main(int argc, char *argv[])
     MacOSController macOSController;
     macOSController.disableAppNap();
 
-    QApplication app(argc, argv);
+    QGuiApplication app(argc, argv);
 
     app.setOrganizationName("Some Humans");
     app.setOrganizationDomain("somehumans.com");
@@ -30,6 +27,9 @@ int main(int argc, char *argv[])
     engine.addImageProvider("tray_icon_provider", new TrayImageProvider());
     engine.addImageProvider("notification_dot_provider", new NotificationDotProvider());
     macOSController.setEngine(&engine);
+
+    QObject::connect(&engine, &QQmlApplicationEngine::quit,
+                     &app, &QCoreApplication::quit);
 
     const QUrl url(QStringLiteral("qrc:/main.qml"));
 


### PR DESCRIPTION
## Summary
- drop QtWidgets requirement from build
- handle tray quit action by closing window and quitting app
- connect QML quit signal to `QCoreApplication::quit`

## Testing
- `cmake ../src`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_687b72108568833092e54b915fedb843