### PR TITLE
Add basic WebAssembly target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Building from source:
     $ make -j
     $ ./Pilorama
 
+### WebAssembly
+
+Qt for WebAssembly build requires the Emscripten toolchain and a Qt installation
+compiled with WebAssembly support. After installing those dependencies, the app
+can be built with:
+
+    $ emcmake cmake ../src -DQT_HOST_PATH=/path/to/qt
+    $ make -j
+
+The resulting `Pilorama.html` can be served from any HTTP server. Note that the
+WebAssembly build disables the system tray icon and preset file import/export
+functionality.
+
 
 ## Development / Code of Conduct 
 #### Release Process

--- a/src/Components/ExternalDrop.qml
+++ b/src/Components/ExternalDrop.qml
@@ -45,12 +45,15 @@ Item{
         onExited: {
                 externalDrop.validFile = false
         }
-        onDropped: if (drop.hasText) {
+        onDropped: if (Qt.platform.os !== "wasm" && drop.hasText) {
             if (drop.proposedAction == Qt.MoveAction || drop.proposedAction == Qt.CopyAction) {
 
-                masterModel.data = fileDialogue.openFile(drop.text).data
-                masterModel.title = fileDialogue.openFile(drop.text).title
-                masterModel.load()
+                var file = fileDialogue.item ? fileDialogue.item.openFile(drop.text) : null
+                if (file) {
+                    masterModel.data = file.data
+                    masterModel.title = file.title
+                    masterModel.load()
+                }
 
                 drop.acceptProposedAction()
                 externalDrop.validFile = false

--- a/src/Components/Preferences.qml
+++ b/src/Components/Preferences.qml
@@ -54,6 +54,7 @@ Item {
 
         PreferenceItem {
             id: closeOnQuit
+            visible: Qt.platform.os !== "wasm"
             cellHeight: preferences.cellHeight
             fontSize: preferences.fontSize
             checked: !window.quitOnClose

--- a/src/Components/Sequence/Footer.qml
+++ b/src/Components/Sequence/Footer.qml
@@ -98,21 +98,23 @@ Rectangle {
 
     Icon {
         id: loadButton
+        visible: Qt.platform.os !== "wasm"
         glyph: "\uea0b"
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
 
-        onReleased: { fileDialogue.openDialogue() }
+        onReleased: { if (fileDialogue.item) fileDialogue.item.openDialogue() }
 
     }
 
     Icon {
         id: saveButton
+        visible: Qt.platform.os !== "wasm"
         glyph: "\uea07"
         anchors.left: loadButton.right
         anchors.verticalCenter: parent.verticalCenter
 
-        onReleased: { fileDialogue.saveDialogue() }
+        onReleased: { if (fileDialogue.item) fileDialogue.item.saveDialogue() }
 
     }
 }

--- a/src/FileDialogue.qml
+++ b/src/FileDialogue.qml
@@ -11,11 +11,13 @@ Item{
     property var title: masterModel.title
 
     function openDialogue(){
-        openFileDialog.open()
+        if (Qt.platform.os !== "wasm")
+            openFileDialog.open()
     }
 
     function saveDialogue(){
-        saveFileDialog.open()
+        if (Qt.platform.os !== "wasm")
+            saveFileDialog.open()
     }
 
     function getTitle(url){
@@ -24,6 +26,9 @@ Item{
     }
 
     function openFile(url) {
+        if (Qt.platform.os === "wasm")
+            return { title: "", data: "" }
+
         var request = new XMLHttpRequest();
         request.open("GET", url, false);
         request.send(null)
@@ -31,6 +36,9 @@ Item{
     }
 
     function saveFile(url) {
+        if (Qt.platform.os === "wasm")
+            return ""
+
         var request = new XMLHttpRequest();
         request.open("PUT", url, true); // async false created empty files on macos
         request.send(masterModel.data);
@@ -39,6 +47,7 @@ Item{
 
     FileDialog {
         id: openFileDialog
+        visible: Qt.platform.os !== "wasm"
         nameFilters: ["JSON files (*.json)"]
         currentFolder: StandardPaths.writableLocation(StandardPaths.DesktopLocation)
 
@@ -51,6 +60,7 @@ Item{
 
     FileDialog {
         id: saveFileDialog
+        visible: Qt.platform.os !== "wasm"
         fileMode: FileDialog.SaveFile
         nameFilters: ["JSON files (*.json)"]
         defaultSuffix : 'json'

--- a/src/FileDialogueStub.qml
+++ b/src/FileDialogueStub.qml
@@ -1,0 +1,9 @@
+import QtQuick
+
+QtObject {
+    // Stub for platforms without file system access
+    function openDialogue() {}
+    function saveDialogue() {}
+    function openFile(url) { return { title: "", data: "" } }
+    function saveFile(url) { return "" }
+}

--- a/src/NotificationSystem.qml
+++ b/src/NotificationSystem.qml
@@ -33,12 +33,13 @@ QtObject {
 
     function sendWithSound(name) {
         soundNotification.play();
-        tray.send(name)
+        if (tray.item && tray.item.send)
+            tray.item.send(name)
     }
 
     function sendFromItem(item) {
         sendWithSound(masterModel.get(item.id).name)
-        if (appSettings.showOnSegmentStart)
-            tray.popUp()
+        if (appSettings.showOnSegmentStart && tray.item && tray.item.popUp)
+            tray.item.popUp()
     }
 }

--- a/src/TrayIconStub.qml
+++ b/src/TrayIconStub.qml
@@ -1,0 +1,7 @@
+import QtQuick
+
+QtObject {
+    // Stub for platforms without system tray support
+    function send(name) {}
+    function popUp() {}
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,10 @@ int main(int argc, char *argv[])
 
     engine.rootContext()->setContextProperty("MacOSController", &macOSController);
 
-	qputenv("QML_XHR_ALLOW_FILE_WRITE", QByteArray("1"));
-	qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+#ifndef Q_OS_WASM
+    qputenv("QML_XHR_ALLOW_FILE_WRITE", QByteArray("1"));
+    qputenv("QML_XHR_ALLOW_FILE_READ", QByteArray("1"));
+#endif
 
     engine.load(url);
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -82,8 +82,7 @@ ApplicationWindow {
                 if (appSettings.showInDock) {
                     MacOSController.hideFromDock()
                 }
-            }
-            else {
+            } else if (Qt.platform.os !== "wasm") {
                 window.visibility = ApplicationWindow.Minimized;
             }
         }
@@ -183,8 +182,9 @@ ApplicationWindow {
         durationSettings: durationSettings
     }
 
-    TrayIcon {
+    Loader {
         id: tray
+        source: Qt.platform.os === "wasm" ? "TrayIconStub.qml" : "TrayIcon.qml"
     }
 
     NotificationSystem {
@@ -199,8 +199,9 @@ ApplicationWindow {
         id: clock
     }
 
-    FileDialogue {
+    Loader {
         id: fileDialogue
+        source: Qt.platform.os === "wasm" ? "FileDialogueStub.qml" : "FileDialogue.qml"
     }
 
     QtObject {

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -27,7 +27,9 @@
         <file>PiloramaTimer.qml</file>
         <file>MouseTracker.qml</file>
         <file>TrayIcon.qml</file>
+        <file>TrayIconStub.qml</file>
         <file>FileDialogue.qml</file>
+        <file>FileDialogueStub.qml</file>
         <file>MasterModel.qml</file>
         <file>ModelBurner.qml</file>
         <file>Components/Colors.qml</file>


### PR DESCRIPTION
## Summary
- provide a `TrayIconStub.qml` for environments without a system tray
- load the tray icon component via `Loader` and disable on WebAssembly
- avoid showing tray related preference on WebAssembly
- make notification system work with the loaded tray component
- wrap qputenv calls for non-WASM builds
- document WebAssembly build steps
- disable preset import/export on WebAssembly

## Testing
- `cmake ../src`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_687b7a1f4b3c833094868494463af9c7